### PR TITLE
DLS-340 MemoryCache konfiguration über Config-File

### DIFF
--- a/CMI/Host/DataFeed/App.config
+++ b/CMI/Host/DataFeed/App.config
@@ -25,7 +25,7 @@
 	<system.runtime.caching>
 		<memoryCache>
 			<namedCaches>
-				<add name="Default" cacheMemoryLimitMegabytes="4096" physicalMemoryLimitPercentage="20" pollingInterval="00:02:00" />
+				<add name="Default" cacheMemoryLimitMegabytes="@@CMI.Host.DataFeed.MemoryCache.CacheMemoryLimitMegabytes@@" physicalMemoryLimitPercentage="@@CMI.Host.DataFeed.MemoryCache.PhysicalMemoryLimitPercentage@@" pollingInterval="00:02:00" />
 			</namedCaches>
 		</memoryCache>
 	</system.runtime.caching>

--- a/CMI/Host/Harvest/App.config
+++ b/CMI/Host/Harvest/App.config
@@ -13,7 +13,7 @@
 	<system.runtime.caching>
 		<memoryCache>
 			<namedCaches>
-				<add name="Default" cacheMemoryLimitMegabytes="4096" physicalMemoryLimitPercentage="20" pollingInterval="00:02:00" />
+				<add name="Default" cacheMemoryLimitMegabytes="@@CMI.Host.Harvest.MemoryCache.CacheMemoryLimitMegabytes@@" physicalMemoryLimitPercentage="@@CMI.Host.Harvest.MemoryCache.PhysicalMemoryLimitPercentage@@" pollingInterval="00:02:00" />
 			</namedCaches>
 		</memoryCache>
 	</system.runtime.caching>


### PR DESCRIPTION
Ich habe festgestellt, dass die Konfiguration für den MemoryCache unglücklich ist. WIr haben da vorher drin gehabt, dass eine Instanz von Harvester und DataFeed maximal je 40 GB Speicher Nutzen darf und/oder je 20% vom Gesamtspeicher. Wenn wir dann noch 4 Instanzen haben, dann gehen bereits 80% des Memory für den Harvester drauf...

Neu sind diese Werte konfigurierbar und wir sollten diese herunternehmen. 
Alternativ könnten wir diese auch auf 0 setzen, wodurch .NET selber schaut was das Optimum wäre. 

Folgende Einträge im Secrets File sind notwendig, mit Vorschlag für die maximalen Grössen

	"@@CMI.Host.DataFeed.MemoryCache.CacheMemoryLimitMegabytes@@": 0,
	"@@CMI.Host.DataFeed.MemoryCache.PhysicalMemoryLimitPercentage@@": 2,
	"@@CMI.Host.Harvest.MemoryCache.CacheMemoryLimitMegabytes@@": 0,
	"@@CMI.Host.Harvest.MemoryCache.PhysicalMemoryLimitPercentage@@": 4,