### PR TITLE
DLS-477 12: Diverse Anpassungen Benennungen und Url hinter Logo (Punk 2)

### DIFF
--- a/CMI/CustomerScripts/ETH/MFA/customer.translations.de.json
+++ b/CMI/CustomerScripts/ETH/MFA/customer.translations.de.json
@@ -458,5 +458,11 @@
       "changeLoginData": " ",
       "changeLoginDataLink": " "
     }
+  },
+  "navigation": {
+    "information": {
+      "protectionAndPetitions": "Einsichtsgesuche",
+      "protectionAndPetitionsTeaserText": "Informationen zu Unterlagen, die unter Schutzfrist stehen, sowie den nötigen Einsichtsgesuchen."
+    }
   }
 }

--- a/CMI/CustomerScripts/ETH/MFA/customer.translations.en.json
+++ b/CMI/CustomerScripts/ETH/MFA/customer.translations.en.json
@@ -462,5 +462,11 @@
       "changeLoginData": " ",
       "changeLoginDataLink": " "
     }
+  },
+  "navigation": {
+    "information": {
+      "protectionAndPetitions": "Requests to consult records",
+      "protectionAndPetitionsTeaserText": "Information about documents that are subject to a closure period, and the consultation requests required."
+    }
   }
 }

--- a/CMI/CustomerScripts/ETH/TMA/customer.translations.de.json
+++ b/CMI/CustomerScripts/ETH/TMA/customer.translations.de.json
@@ -458,5 +458,11 @@
       "changeLoginData": " ",
       "changeLoginDataLink": " "
     }
+  },
+  "navigation": {
+    "information": {
+      "protectionAndPetitions": "Einsichtsgesuche",
+      "protectionAndPetitionsTeaserText": "Informationen zu Unterlagen, die unter Schutzfrist stehen, sowie den nötigen Einsichtsgesuchen."
+    }
   }
 }

--- a/CMI/CustomerScripts/ETH/TMA/customer.translations.en.json
+++ b/CMI/CustomerScripts/ETH/TMA/customer.translations.en.json
@@ -462,5 +462,11 @@
       "changeLoginData": " ",
       "changeLoginDataLink": " "
     }
+  },
+  "navigation": {
+    "information": {
+      "protectionAndPetitions": "Requests to consult records",
+      "protectionAndPetitionsTeaserText": "Information about documents that are subject to a closure period, and the consultation requests required."
+    }
   }
 }

--- a/CMI/Web.Clients/web-frontend/src/app/modules/client/components/navigation/content/navigationContent.component.html
+++ b/CMI/Web.Clients/web-frontend/src/app/modules/client/components/navigation/content/navigationContent.component.html
@@ -117,8 +117,11 @@
 											</a>
 										</li>
 										<li role="presentation">
-											<a href="#{{ '/de/informationen/schutzfristen-und-einsichtsgesuche' | localizeLink }}">
+											<a *ngif="!useShortPetitionsLink" href="#{{ '/de/informationen/schutzfristen-und-einsichtsgesuche' | localizeLink }}">
 												{{ 'Schutzfristen & Einsichtsgesuche' | translate:'navigation.information.protectionAndPetitions' }}
+											</a>
+											<a *ngif="useShortPetitionsLink" href="#{{ '/de/einsichtsgesuche' | localizeLink }}">
+												{{ 'Einsichtsgesuche' | translate:'navigation.information.protectionAndPetitions' }}
 											</a>
 										</li>
 										<li role="presentation">
@@ -440,8 +443,11 @@
 						<div class="yamm-content container-fluid">
 							<i class="glyphicon glyphicon-scale-classic" aria-hidden="true"></i>
 							<h4>
-								<a href="#{{ '/de/informationen/schutzfristen-und-einsichtsgesuche' | localizeLink }}">
+								<a *ngIf="!useShortPetitionsLink" href="#{{ '/de/informationen/schutzfristen-und-einsichtsgesuche' | localizeLink }}">
 									{{'Schutzfristen & Einsichtsgesuche' | translate:'navigation.information.protectionAndPetitions' }}
+								</a>
+								<a *ngIf="useShortPetitionsLink" href="#{{ '/de/informationen/einsichtsgesuche' | localizeLink }}">
+									{{'Einsichtsgesuche' | translate:'navigation.information.protectionAndPetitions' }}
 								</a>
 							</h4>
 							<p>

--- a/CMI/Web.Clients/web-frontend/src/app/modules/client/components/navigation/content/navigationContent.component.ts
+++ b/CMI/Web.Clients/web-frontend/src/app/modules/client/components/navigation/content/navigationContent.component.ts
@@ -16,6 +16,7 @@ export class NavigationContentComponent implements AfterViewInit {
 	public mobileMainNavOpen = false;
 	public mobileUserNavOpen = false;
 	private showThematicoverview  = false;
+	private _useShortPetitionsLink = false;
 	private hasChatbot: boolean;
 
 	constructor(private _context: ClientContext,
@@ -31,6 +32,7 @@ export class NavigationContentComponent implements AfterViewInit {
 		this._elem = this._elemRef.nativeElement;
 		this.hasChatbot = this._cfg.getSetting('chatbot.urlForChatBot')?.length > 0;
 		this.showThematicoverview = this._cfg.getSetting('showThematicOverview').showThematicOverview;
+		this._useShortPetitionsLink = this._cfg.getSetting('useShortPetitionsLink').useShortPetitionsLink;
 
 		this._router.events.subscribe(event => {
 			if (event instanceof NavigationStart) {
@@ -118,6 +120,9 @@ export class NavigationContentComponent implements AfterViewInit {
 	}
 	public get authenticated(): boolean {
 		return this._context.authenticated;
+	}
+	public get useShortPetitionsLink(): boolean {
+		return this._useShortPetitionsLink;
 	}
 
 	public login(): void {

--- a/CMI/Web.Clients/web-frontend/src/app/routes.ts
+++ b/CMI/Web.Clients/web-frontend/src/app/routes.ts
@@ -103,6 +103,15 @@ export const defaultRouteChildren: any = [
 				component: StaticPageComponent
 			},
 			{
+				path: 'einsichtsgesuche',
+				_localize: {
+					'fr': 'demandes-de-consultation',
+					'it': 'domande-di-consultazione',
+					'en': 'requests-to-consult-records'
+				},
+				component: StaticPageComponent
+			},
+			{
 				path: 'zitieren-und-publizieren',
 				_localize: {
 					'fr': 'citer-et-publier',

--- a/CMI/Web/CMI.Web.Common/Helpers/WebHelper.cs
+++ b/CMI/Web/CMI.Web.Common/Helpers/WebHelper.cs
@@ -55,6 +55,7 @@ namespace CMI.Web.Common.Helpers
         public static string UrlForChatBot => GetStringSetting("urlForChatBot", "");
 
         public static bool ShowThematicOverview => GetBooleanSetting("showThematicOverview", false);
+        public static bool UseShortPetitionsLink => GetBooleanSetting("useShortPetitionsLink", false);
 
         public static string PublicClientUrl => GetStringSetting("publicClientUrl", "https://www.recherche.bar.admin.ch/recherche");
 

--- a/CMI/Web/CMI.Web.Common/api/AppSettings.cs
+++ b/CMI/Web/CMI.Web.Common/api/AppSettings.cs
@@ -158,6 +158,7 @@ namespace CMI.Web.Common.api
                 SettingsHelper.InjectInfo(settingsObj, "viewer", "url", WebHelper.ViewerUrl);
 
                 SettingsHelper.InjectInfo(settingsObj, "showThematicOverview", "showThematicOverview", WebHelper.ShowThematicOverview);
+                SettingsHelper.InjectInfo(settingsObj, "useShortPetitionsLink", "useShortPetitionsLink", WebHelper.UseShortPetitionsLink);
             }
         }
 

--- a/CMI/Web/CMI.Web.Frontend/App_Data_Template/web.cmi.config
+++ b/CMI/Web/CMI.Web.Frontend/App_Data_Template/web.cmi.config
@@ -23,6 +23,7 @@
   <add key="supportedLanguagesForChatBot" value="" />
   <add key="urlForChatBot" value="" />
   <add key="showThematicOverview" value="false" />
+  <add key="useShortPetitionsLink" value="@@CMI.Web.Frontend.AppData_Template.UseShortPetitionsLink@@" />
 
   <add key="swaggerBaseUrl" value="@@CMI.Web.Frontend.AppData_Template.PublicClientUrl@@" />
 

--- a/CMI/Web/CMI.Web.Frontend/content/de/informationen/einsichtsgesuche.html
+++ b/CMI/Web/CMI.Web.Frontend/content/de/informationen/einsichtsgesuche.html
@@ -1,0 +1,227 @@
+﻿<!DOCTYPE HTML>
+<html lang="de">
+<head>
+    <meta name="language" content="de">
+</head>
+<body>
+    <div class="container container-main">
+        <!--content-begin-->
+        <div id="content-wrapper">
+            <div class="container-fluid hidden-xs">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <div class="mod mod-breadcrumb">
+                            <h2 id="br1" class="hidden">Breadcrumb</h2>
+                            <ol class="breadcrumb" aria-labelledby="br1">
+                                <li><a href="/de/" title="Schweizerisches Bundesarchiv"><i class="glyphicon glyphicon-home"></i></a><span class="icon icon--greater"></span></li>
+                                <li class="active" aria-selected="true" aria-label="current page">Schutzfristen und Einsichtsgesuche</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-sm-12 col-md-12 main-column" id="content" role="main">
+                        <div class="row">
+                            <div class="col-md-8 main-content">
+                                <h1>Schutzfristen und Einsichtsgesuche</h1>
+                                
+                                <p>
+                                    <b>
+                                        Das Bundesgesetz über die Archivierung (BGA) sowie das Öffentlichkeitsgesetz (BGÖ) 
+                                        regeln den Zugang zu den Unterlagen des Bundesarchivs. Unter anderem legt das BGA
+                                        Schutzfristen für Unterla-gen fest. Bis zu deren Ablauf ist eine Konsultation der
+                                        Unterlagen nur mit einer Bewilligung möglich. Danach sind sie frei und unentgeltlich zugänglich.
+                                    </b>
+                                </p>
+                                
+
+                                <p>
+                                    Das <a href="https://www.admin.ch/opc/de/classified-compilation/19994756/index.html">Bundesgesetz über die Archivierung</a> (BGA, SR 152.1)
+                                    unterscheidet vier Arten von Schutzfristen (siehe unten).
+                                    Die Mehrheit der Unterlagen im Bundesarchiv unterliegt keiner Schutzfrist mehr. 
+                                    Von den restlichen Unterlagen fallen die meisten unter eine Schutzfrist von 30 Jahren nach Art. 9 BGA.
+                                    <br/>
+                                    <br/>
+                                    Falls Sie Einsicht in Unterlagen wünschen, die noch einer gesetzlichen Schutzfrist unterliegen,
+                                    müssen Sie beim Bundesarchiv ein Gesuch um Einsichtnahme stellen. Möchten weitere Personen in 
+                                    dieselben Unterlagen Einsicht nehmen (z. B. Familienmitglieder), müssen auch diese ein Gesuch 
+                                    einreichen.
+                                    <br />
+                                    <br />
+                                    Für archivierte Unterlagen, die ab dem 1. Juli 2006 erstellt worden sind,
+                                    kann der Zugang nach BGA sowie auch 
+                                    <a href="https://www.admin.ch/opc/de/classified-compilation/20022540/index.html">
+                                        gemäss dem Bundesgesetz über das Öffentlichkeitsprinzip der Verwaltung 
+                                    </a>
+                                    (BGÖ, SR 152.3) erfolgen. BGA und BGÖ sind in diesem Fall parallel anwendbar.
+                                    Die zuständige Stelle beurteilt Gesuche nach der für die gesuchstellende Person vorteilhafteren 
+                                    Variante.
+                                </p>
+                                
+
+                                <h2>Einsichtsgesuche</h2>
+                                <p>
+                                    Um ein Einsichtsgesuch zu stellen, legen Sie das gewünschte Dossier in
+                                    den Bestellkorb und wählen dann die Option «Einsichtsgesuch stellen».
+                                    Wenn Sie Unterlagen einsehen möchten, die Ihre eigene Person betreffen,
+                                    müssen Sie sich vorgängig als Nutzer/in identifizieren 
+                                    (siehe 
+                                    <a href="/#/de/information/registrieren-und-identifizieren">
+                                        Registrieren und Identifizieren
+                                    </a>
+                                    ). Das BAR leitet Ihr Gesuch an die Stelle weiter,
+                                    die über die Einsichtnahme entscheidet. Mit einem Entscheid können Sie in der Regel innerhalb von vier Wochen rechnen.
+                                    Im Fall von umfangreichen Gesuchen kann sich die Bearbeitungszeit verlängern.
+                                </p>
+                                
+
+                                <h2>Einsichtsbewilligungen</h2>
+                                <p>
+                                    Die Mehrzahl der Gesuche wird – zum Teil unter Auflagen – bewilligt. Wir informieren Sie schriftlich über die Einsichtsbewilligungen. 
+                                    Die zur Einsicht freigegebenen Unterlagen müssen Sie anschliessend über Ihr Benutzerkonto bestellen, um sie online oder im Lesesaal einzusehen.
+                                    <br/>
+                                    Die Einsichtsbewilligung gilt in der Regel für die Einsichtnahme in die Unterlagen. Wenn Sie Dokumen-te veröffentlichen wollen, 
+                                    nehmen Sie mit der/dem zuständigen Sachbearbeitenden Kontakt auf.
+                                </p>
+                                
+
+                                <h2>Einsichtsverweigerungen</h2>
+                                <p>
+                                    Auch über Einsichtsverweigerungen werden Sie schriftlich informiert. 
+                                    Danach können Sie zu diesem Entscheid eine beschwerdefähige Verfügung verlangen (BGA)
+                                    bzw. ein Schlichtungsverfahren anstre-ben (BGÖ).
+                                </p>
+                                
+
+                                <h2>Schutzfristen gemäss Bundesgesetz über die Archivierung (BGA)</h2>
+
+                                <h3>Schutzfrist gemäss Art. 9 BGA</h3>
+                                <p>
+                                    Art. 9 BGA legt eine Schutzfrist von 30 Jahren fest. Für die Berechnung der Laufzeit der Schutzfrist ist das 
+                                    Abschlussjahr eines Dossiers massgebend, d. h. das Datum des jüngsten Dokuments.
+                                    <br/>
+                                    Unterlagen, die bereits vor ihrer Ablieferung an das Bundesarchiv öffentlich zugänglich waren, 
+                                    bleiben auch weiterhin öffentlich zugänglich.
+                                </p>
+
+                                <h3>Schutzfrist gemäss Art. 11 BGA</h3>
+                                <p>
+                                    Unterlagen, die nach Personennamen erschlossen sind und besonders schützenswerte Personendaten oder Persönlichkeitsprofile
+                                    gemäss Datenschutzgesetz enthalten, unterliegen einer verlängerten Schutzfrist von 50 Jahren. Die Verlängerung der Schutzfrist
+                                    von 30 auf 50 Jahre wird hinfällig, wenn die betroffene Person schriftlich einer Einsichtnahme zugestimmt hat oder wenn die
+                                    betroffene Person seit mehr als drei Jahren verstorben ist. Vorbehalten bleiben Art. 12.1 und 12.2 BGA.
+                                </p>
+
+                                <h3>Schutzfrist gemäss Art. 12.1 BGA</h3>
+                                <p>
+                                    Für bestimmte Kategorien von Unterlagen kann der Bundesrat die Schutzfrist verlängern, 
+                                    wenn ein überwiegendes schutzwürdiges öffentliches oder privates Interesse gegen eine Einsichtnahme spricht.
+                                    Die entsprechenden Unterlagen sind im jährlich publizierten 
+                                    <a href="https://www.admin.ch/opc/de/classified-compilation/19994752/index.html">
+                                        Anhang 3 der Verordnung zum BGA
+                                    </a>
+                                    (VBGA, SR 152.11) aufgelistet.
+                                </p>
+                                
+                                <h3>Schutzfrist gemäss Art. 12.2 BGA</h3>
+                                <p>
+                                    Besteht im Einzelfall (in der Regel bei einem einzelnen Dossier) ein überwiegendes schutzwürdiges
+                                    öffentliches oder privates Interesse, kann die abliefernde Stelle oder das Bundesarchiv die Schutzfrist 
+                                    verlängern.
+                                </p>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="context-column">
+                                    <a name="context-sidebar"></a>
+                                    <div class="mod mod-contactbox">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active">
+                                                <a href="kontakt.html#contact" data-toggle="tab">
+                                                    Kontakt
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="kontakt.html#map" data-toggle="tab">
+                                                    Karte
+                                                </a>
+                                            </li>
+                                        </ul>
+                                        <div class="tab-content tab-border">
+                                            <div class="tab-pane active" id="contact" data-editable>
+                                                <h2 class="sr-only visible-print-block">Kontakt</h2>
+                                                <h3>Schweizerisches Bundesarchiv</h3>
+                                                <p>
+                                                    Archivstrasse 24<br>
+                                                    3003 Bern
+                                                </p>
+                                                <dl class="dl-horizontal">
+                                                    <dt>
+                                                        <abbr title="">
+                                                            Tel.
+                                                        </abbr>
+                                                    </dt>
+                                                    <dd>
+                                                        <a href="tel:+41 58 462 89 89">
+                                                            +41 58 462 89 89
+                                                        </a>
+                                                    </dd>
+                                                    <dt>
+                                                        Fax
+                                                    </dt>
+                                                    <dd>
+                                                        +41 58 462 78 23
+                                                    </dd>
+                                                </dl>
+                                                <p>
+                                                    <a class="icon icon--before icon--message" href="mailto:info@bar.admin.ch">
+                                                        E-Mail
+                                                    </a>
+                                                </p>
+                                                <h4>Öffnungszeiten Lesesaal</h4>
+                                                <p>Di-Do, 09.00-19.00 Uhr</p>
+                                                <p>
+                                                    <a href="kontakt.html">Details und Schliessungen</a>
+                                                </p>
+                                                <p>
+                                                    <a class="icon icon--before icon--print print js-print-contact" href="kontakt.html#" title="Druckversion">
+                                                        Kontaktinformationen drucken
+                                                    </a>
+                                                </p>
+                                            </div>
+                                            <div class="tab-pane" id="map" data-editable>
+                                                <h2 class="sr-only visible-print-block">Karte</h2>
+                                                <h3>Schweizerisches Bundesarchiv</h3>
+                                                <p>
+                                                    Archivstrasse 24
+                                                    <br>
+                                                    3003
+                                                    Bern
+                                                </p>
+                                                <p>
+                                                <p>
+                                                    <a href="http://www.openstreetmap.org/?mlat=46.94037&amp;mlon=7.44658#map=18/46.94037/7.44658&amp;layers=T" class="icon icon--after icon--external" target="_blank">
+                                                        Auf Karte anzeigen
+                                                    </a>
+                                                </p>
+                                                </p>
+                                                <p>
+                                                    <a class="icon icon--before icon--print print js-print-contact" href="kontakt.html#" title="Druckversion">
+                                                        Kontaktinformationen drucken
+                                                    </a>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!--content-end-->
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Da die ETH eine andere URL gewünscht hat, für "de/informationen/schutzfristen-und-einsichtsgesuche" und nur "de/informationen/einsichtsgesuche" möchte, habe ich eine zweite Route definiert und über die Settings kann gewählt werden, ob der lange oder der kurze Pfad verwendet werden soll.

Beim Deployment muss man darauf achten, dass das neue Setting in die Parameter-Datei kommt. Zudem muss das bestehende HTML File noch kopiert und umbenannt werden.