### PR TITLE
feature/DLS-485-Umsetzung-Support-ETH-2025.07

### DIFF
--- a/CMI/Web.Clients/web-core/src/lib/core/services/translation.service.ts
+++ b/CMI/Web.Clients/web-core/src/lib/core/services/translation.service.ts
@@ -12,7 +12,7 @@ export class TranslationService {
 	private _texts: { [key: string]: any };
 	private _textsCustomer: { [key: string]: any };
 
-	private _commonKey: '_';
+	private _commonKey = '_';
 	private _showMissingInfo = false;
 	private _isLocalhost = false;
 


### PR DESCRIPTION
Fix syntax for _commonKey initialization
Changed the initialization of _commonKey from a type annotation to an assignment for correct TypeScript syntax.

<img width="975" height="232" alt="image" src="https://github.com/user-attachments/assets/77642225-ef05-4877-aab4-9643b0d85576" />
