### PR TITLE
fix memory leak

### DIFF
--- a/CMI/Contract/Common/Compiler/DynamicScriptProvider.cs
+++ b/CMI/Contract/Common/Compiler/DynamicScriptProvider.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Linq;
+﻿using Microsoft.CSharp;
+using System;
 using System.CodeDom.Compiler;
-using System.IO;
-
-using Microsoft.CSharp;
+using System.Linq;
+using System.Reflection;
 
 namespace CMI.Contract.Common.Compiler
 {
@@ -11,6 +10,10 @@ namespace CMI.Contract.Common.Compiler
     {
         private readonly IDynamicScriptLocator scriptLocator;
         private readonly CSharpCodeProvider compiler;
+
+        private Assembly cachedAssembly;
+        private string cachedScriptHash;
+        private readonly object @lock = new object();
 
         public static string[] References => AppDomain.CurrentDomain.GetAssemblies()
                                                                      .Where(a => !a.IsDynamic)
@@ -22,21 +25,34 @@ namespace CMI.Contract.Common.Compiler
             compiler = compilerInstance;
         }
 
-        public T GetInstanceByType<T>() 
+        public T GetInstanceByType<T>()
         {
             string script = scriptLocator.GetCustomScript();
-            var options = new CompilerParameters() { GenerateInMemory = true };
-            foreach(var reference in References)
-            {
-                options.ReferencedAssemblies.Add(reference);
-            }
-                
-            var result = compiler.CompileAssemblyFromSource(options, script);
-            EnsureResult(result);
 
-            var targetType = result.CompiledAssembly.GetTypes()
-                                                .Where(t => typeof(T).IsAssignableFrom(t))
-                                                .FirstOrDefault();
+            string scriptHash = ComputeHash(script);
+
+            lock (@lock)
+            {
+                // Nur neu kompilieren, wenn sich das Script geändert hat
+                if (cachedAssembly == null || cachedScriptHash != scriptHash)
+                {
+                    var options = new CompilerParameters() { GenerateInMemory = true };
+                    foreach (var reference in References)
+                    {
+                        options.ReferencedAssemblies.Add(reference);
+                    }
+
+                    var result = compiler.CompileAssemblyFromSource(options, script);
+                    EnsureResult(result);
+
+                    cachedAssembly = result.CompiledAssembly;
+                    cachedScriptHash = scriptHash;
+                }
+            }
+
+            var targetType = cachedAssembly
+                .GetTypes()
+                .FirstOrDefault(t => typeof(T).IsAssignableFrom(t));
 
             return (T) Activator.CreateInstance(targetType); 
         }
@@ -49,7 +65,15 @@ namespace CMI.Contract.Common.Compiler
                 throw new Exception(String.Join(Environment.NewLine, messages));
             }
         }
+
+        private static string ComputeHash(string input)
+        {
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            var bytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input));
+            return Convert.ToBase64String(bytes);
+        }
     }
+    
     public class EmptyScriptLocator : IDynamicScriptLocator
     {
         public string GetCustomScript()

--- a/CMI/Manager/DataFeed/Infrastructure/ContainerConfigurator.cs
+++ b/CMI/Manager/DataFeed/Infrastructure/ContainerConfigurator.cs
@@ -37,7 +37,7 @@ namespace CMI.Manager.DataFeed.Infrastructure
             builder.RegisterType<AISDataProviderFactory>().As<IAISDataProviderFactory>();
             builder.RegisterType<ArchiveRecordBuilderFactory>().As<IArchiveRecordBuilderFactory>();
             builder.RegisterType<CSharpCodeProvider>().AsSelf().SingleInstance();
-            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>();
+            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>().SingleInstance();
             builder.Register(ctx =>
             {
                 return new EmptyScriptLocator();

--- a/CMI/Manager/Harvest/Infrastructure/ContainerConfigurator.cs
+++ b/CMI/Manager/Harvest/Infrastructure/ContainerConfigurator.cs
@@ -42,7 +42,7 @@ namespace CMI.Manager.Harvest.Infrastructure
             var connectionString = DbConnectionSetting.Default.ConnectionStringEF;
             builder.RegisterType<LesesaalDb>().AsSelf().WithParameter(nameof(connectionString), connectionString);
             builder.RegisterType<CSharpCodeProvider>().AsSelf().SingleInstance();
-            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>();
+            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>().SingleInstance();
             builder.Register(ctx =>
             {
                var path = Settings.Default.CustomScriptPath;

--- a/CMI/Manager/Index/Infrastructure/ContainerConfigurator.cs
+++ b/CMI/Manager/Index/Infrastructure/ContainerConfigurator.cs
@@ -33,7 +33,7 @@ namespace CMI.Manager.Index.Infrastructure
             builder.RegisterType<LogDataAccess>().As<ILogDataAccess>();
             builder.RegisterType<ParameterHelper>().As<IParameterHelper>();
             builder.RegisterType<CSharpCodeProvider>().AsSelf().SingleInstance();
-            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>();
+            builder.RegisterType<DynamicScriptProvider>().As<IDynamicScriptProvider>().SingleInstance();
             builder.Register(ctx =>
             {
                 var path = Settings.Default.CustomScriptPath;


### PR DESCRIPTION
```
// DynamicScriptProvider.cs
public T GetInstanceByType<T>()
{
    string script = scriptLocator.GetCustomScript(); // Liest Datei von Disk

    var options = new CompilerParameters() { GenerateInMemory = true };
    foreach(var reference in References)
    {
        options.ReferencedAssemblies.Add(reference); // Alle geladenen Assemblies
    }

    // 🔴 HIER IST DAS LEAK:
    var result = compiler.CompileAssemblyFromSource(options, script);
    //   ↑ Kompiliert bei JEDEM Aufruf eine neue Assembly im Speicher!
    //   ↑ GenerateInMemory = true → Assembly landet im AppDomain
    //   ↑ Assemblies können NICHT aus einer AppDomain entladen werden (.NET 4.x)
    //   ↑ Jede kompilierte Assembly bleibt für immer im RAM

    var targetType = result.CompiledAssembly.GetTypes()...
    return (T) Activator.CreateInstance(targetType);
}
```

In .NET Framework 4.x können Assemblies nicht aus dem AppDomain entladen werden. Jeder kompilierte Script-Aufruf ist dauerhaft im RAM.

Das Hauptproblem ist eindeutig der DynamicScriptProvider – eine Zeile SingleInstance() in drei ContainerConfigurator-Dateien sollte das Leak beheben.